### PR TITLE
기기에서 재생중인 음악의 정보 및 가사를 보여주는 기능

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,35 +1,34 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.p_lyric">
-   <application
-        android:label="p_lyric"
-        android:icon="@mipmap/ic_launcher">
+
+    <application
+        android:icon="@mipmap/ic_launcher"
+        android:label="p_lyric">
         <activity
             android:name=".MainActivity"
-            android:launchMode="singleTop"
-            android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
+            android:launchMode="singleTop"
+            android:theme="@style/LaunchTheme"
             android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues
                  to determine the Window background behind the Flutter UI. -->
             <meta-data
-              android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme" />
             <!-- Displays an Android View that continues showing the launch screen
                  Drawable until Flutter paints its first frame, then this splash
                  screen fades out. A splash screen is useful to avoid any visual
                  gap between the end of Android's launch screen and the painting of
                  Flutter's first frame. -->
             <meta-data
-              android:name="io.flutter.embedding.android.SplashScreenDrawable"
-              android:resource="@drawable/launch_background"
-              />
+                android:name="io.flutter.embedding.android.SplashScreenDrawable"
+                android:resource="@drawable/launch_background" />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
@@ -37,5 +36,13 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <service
+            android:name="com.gomes.nowplaying.NowPlayingListenerService"
+            android:label="NowPlayingListenerService"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
             android:value="2" />
         <service
             android:name="com.gomes.nowplaying.NowPlayingListenerService"
-            android:label="NowPlayingListenerService"
+            android:label="PLyric"
             android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
             <intent-filter>
                 <action android:name="android.service.notification.NotificationListenerService" />

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,5 +41,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSAppleMusicUsageDescription</key>
+    <string>We need this to show you what's currently playing</string>
 </dict>
 </plist>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:nowplaying/nowplaying.dart';
 import 'package:p_lyric/themes.dart';
 import 'package:p_lyric/views/home_page.dart';
 
-void main() => runApp(MyApp());
+void main() async {
+  NowPlaying.instance.start();
+
+  runApp(MyApp());
+}
 
 class MyApp extends StatelessWidget {
   @override

--- a/lib/provider/playing_music_provider.dart
+++ b/lib/provider/playing_music_provider.dart
@@ -1,0 +1,32 @@
+import 'package:get/get.dart';
+import 'package:nowplaying/nowplaying.dart';
+import 'package:p_lyric/servies/melon_lyric_scraper.dart';
+
+class PlayingMusicProvider extends GetxController {
+  PlayingMusicProvider();
+
+  Rx<NowPlayingTrack> _track = NowPlayingTrack.notPlaying.obs;
+  NowPlayingTrack? get track => _track.value;
+
+  String _lyric = '';
+  String get lyric => _lyric;
+
+  @override
+  void onInit() {
+    super.onInit();
+    NowPlaying.instance.stream.listen(_listenTrackEvent);
+    debounce(_track, _updateLyric, time: const Duration(milliseconds: 200));
+  }
+
+  void _updateLyric(NowPlayingTrack track) async {
+    _lyric = await MelonLyricScraper.searchLyric(track.title ?? '');
+    update();
+  }
+
+  void _listenTrackEvent(NowPlayingTrack newTrack) {
+    if (newTrack.isPlaying && _track.value.title != newTrack.title) {
+      _track.value = newTrack;
+      update();
+    }
+  }
+}

--- a/lib/views/home_page.dart
+++ b/lib/views/home_page.dart
@@ -101,11 +101,49 @@ class _CardView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textTheme = Get.textTheme;
+
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(24.0),
-        child: Row(
-          children: [],
+        child: GetBuilder<PlayingMusicProvider>(
+          init: PlayingMusicProvider(),
+          builder: (musicProvider) {
+            final track = musicProvider.track;
+            final icon = track?.image;
+            final title = track?.title ?? '재생중인 음악 없음';
+            final artist = track?.artist ?? '노래를 재생하면 가사가 업데이트됩니다.';
+
+            return Row(
+              children: [
+                ClipRRect( // TODO(민성): 재생 및 다음곡 버튼 구현
+                  borderRadius: BorderRadius.circular(1000.0),
+                  child: icon == null
+                      ? const SizedBox(height: 72, width: 72)
+                      : Image(image: icon, height: 72, width: 72),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: textTheme.subtitle1!.copyWith(fontSize: 18),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        artist,
+                        style: textTheme.subtitle2!.copyWith(
+                          color: Colors.black54,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            );
+          },
         ),
       ),
     );

--- a/lib/views/home_page.dart
+++ b/lib/views/home_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:p_lyric/servies/melon_lyric_scraper.dart';
+import 'package:nowplaying/nowplaying.dart';
+import 'package:p_lyric/provider/playing_music_provider.dart';
 import 'package:p_lyric/views/setting_page.dart';
 import 'package:p_lyric/widgets/default_container.dart';
 
@@ -12,22 +13,20 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
-  final TextEditingController _textEditingController = TextEditingController();
-  String? lyrics;
-
   @override
   void initState() {
     super.initState();
-    _textEditingController.addListener(() {
-      setState(() {});
-    });
-  }
 
-  void _handleSearchButton() async {
-    final result =
-        await MelonLyricScraper.searchLyric(_textEditingController.text);
-    setState(() {
-      lyrics = result;
+    // TODO(민성): 설정 화면 혹은 다이어로그 띄워서 사용자에게 권한에 대해 설명하기
+    NowPlaying.instance.isEnabled().then((bool isEnabled) async {
+      if (!isEnabled) {
+        final granted = await NowPlaying.instance.requestPermissions();
+
+        Get.showSnackbar(GetBar(
+          message: granted ? '권한이 허용됨' : '권한이 허용되지 않음',
+          duration: const Duration(seconds: 3),
+        ));
+      }
     });
   }
 
@@ -55,28 +54,7 @@ class _HomePageState extends State<HomePage> {
         children: [
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 20.0),
-            child: Card(
-              child: Padding(
-                padding: const EdgeInsets.all(24.0),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: TextField(
-                        style: textTheme.subtitle1,
-                        controller: _textEditingController,
-                        onSubmitted: (_) => _handleSearchButton(),
-                      ),
-                    ),
-                    TextButton(
-                      onPressed: _textEditingController.text.isEmpty
-                          ? null
-                          : _handleSearchButton,
-                      child: Text('검색'),
-                    ),
-                  ],
-                ),
-              ),
-            ),
+            child: _CardView(),
           ),
           const SizedBox(height: 22),
           Expanded(
@@ -85,10 +63,25 @@ class _HomePageState extends State<HomePage> {
                 padding: const EdgeInsets.symmetric(horizontal: 24.0),
                 child: SizedBox(
                   width: double.infinity,
-                  child: Text(
-                    lyrics ?? "검색어를 입력하세요.",
+                  child: DefaultTextStyle(
                     style: textTheme.bodyText1!.copyWith(
                       color: Color(0xE6FFFFFF),
+                    ),
+                    child: GetBuilder<PlayingMusicProvider>(
+                      init: PlayingMusicProvider(),
+                      builder: (musicProvider) {
+                        if (musicProvider.track != null) {
+                          final title = musicProvider.track!.title;
+
+                          if (title == null) return Text("검색 결과가 없습니다.");
+
+                          if (musicProvider.lyric.isNotEmpty) {
+                            return Text(musicProvider.lyric);
+                          }
+                          return Center(child: CircularProgressIndicator());
+                        }
+                        return Text("검색어를 입력하세요.");
+                      },
                     ),
                   ),
                 ),
@@ -96,6 +89,24 @@ class _HomePageState extends State<HomePage> {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _CardView extends StatelessWidget {
+  const _CardView({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Row(
+          children: [],
+        ),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -144,6 +144,22 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  nowplaying:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: p-lyric-app
+      resolved-ref: "3f8a321cf62d070fe524a6c407a3a85f2b024f51"
+      url: "https://github.com/jja08111/nowplaying.git"
+    source: git
+    version: "2.0.2"
+  package_info:
+    dependency: transitive
+    description:
+      name: package_info
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,10 @@ dependencies:
   http: ^0.13.3
   get: ^4.3.8
   google_fonts: ^2.1.0
+  nowplaying:
+    git:
+      url: https://github.com/jja08111/nowplaying.git
+      ref: p-lyric-app
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
# What's changed? 🤔

홈 화면의 검색 창을 삭제하고 현재 재생중인 음악의 정보 및 가사가 보이도록 수정하였음. 안드로이드 IOS에서 작동할것으로 기대함.

# What you should know 🙄

- Getx 패키지의 `debounce`함수를 이용하여 200밀리초 이내로 겹치는 명령에 대해서는 무시하고 그 마지막 명령을 실행하도록 하였음. 이는 검색량을 줄일 수 있도록 기대함
- nowPlaying 플러그인이 현재 null-safety 문제로 작동이 안해서 따로 folk 하여 이용중임