### PR TITLE
재생중인 곡 업데이트 문제 수정

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,7 +149,7 @@ packages:
     description:
       path: "."
       ref: p-lyric-app
-      resolved-ref: "3f8a321cf62d070fe524a6c407a3a85f2b024f51"
+      resolved-ref: "0262228e49c184b7fb07f8f7deb3b65a2505f667"
       url: "https://github.com/jja08111/nowplaying.git"
     source: git
     version: "2.0.2"


### PR DESCRIPTION
## 🙄 해결한 문제
삼성 뮤직에서 음악을 재생하고 다음곡으로 넘기는 등 행위를 하였을때 가끔 갱신이 안되는 오류

## 😎 참고
nowplaying 플러그인의 불안정한 작동을 수정하여 해당 문제가 해결되었기를 바람
수정 내용은 https://github.com/jja08111/nowplaying/commit/0262228e49c184b7fb07f8f7deb3b65a2505f667 커밋을 참고

머지 후 테스트 부탁드립니다.