### PR TITLE
PlayingMusicProvider 업데이트

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,7 +40,8 @@
         <service
             android:name="com.gomes.nowplaying.NowPlayingListenerService"
             android:label="PLyric"
-            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.service.notification.NotificationListenerService" />
             </intent-filter>

--- a/lib/provider/playing_music_provider.dart
+++ b/lib/provider/playing_music_provider.dart
@@ -2,6 +2,8 @@ import 'package:get/get.dart';
 import 'package:nowplaying/nowplaying.dart';
 import 'package:p_lyric/services/melon_lyric_scraper.dart';
 
+import 'utils/waiter.dart';
+
 class PlayingMusicProvider extends GetxController {
   PlayingMusicProvider();
 
@@ -15,7 +17,7 @@ class PlayingMusicProvider extends GetxController {
   void onInit() {
     super.onInit();
     NowPlaying.instance.stream.listen(_listenTrackEvent);
-    debounce(_track, _updateLyric, time: const Duration(milliseconds: 200));
+    wait(_track, _updateLyric, time: const Duration(milliseconds: 1000));
   }
 
   void _updateLyric(NowPlayingTrack track) async {

--- a/lib/provider/utils/waiter.dart
+++ b/lib/provider/utils/waiter.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+import 'package:get/get.dart';
+
+/// 초기 실행 혹은 타이머가 작동중이지 않을 때는 바로 [callback]을 실행하며 그 후로 [delay] 동안의
+/// 명령이 끝나야 다음 명령이 실행된다.
+Worker wait<T>(
+    RxInterface<T> listener,
+    WorkerCallback<T> callback, {
+      Duration? time,
+      Function? onError,
+      void Function()? onDone,
+      bool? cancelOnError,
+    }) {
+  final _waiter = _Waiter(delay: time ?? const Duration(milliseconds: 800));
+  StreamSubscription sub = listener.listen(
+        (event) {
+      _waiter(() {
+        callback(event);
+      });
+    },
+    onError: onError,
+    onDone: onDone,
+    cancelOnError: cancelOnError,
+  );
+  return Worker(sub.cancel, '[debounce]');
+}
+
+class _Waiter {
+  final Duration delay;
+  Timer? _timer;
+
+  _Waiter({required this.delay});
+
+  void call(void Function() action) {
+    if (_timer == null || !_timer!.isActive) {
+      action();
+      _timer = Timer(delay, () {});
+    } else {
+      _timer?.cancel();
+      _timer = Timer(delay, action);
+    }
+  }
+
+  /// Notifies if the delayed call is active.
+  bool get isRunning => _timer?.isActive ?? false;
+
+  /// Cancel the current delayed call.
+  void cancel() => _timer?.cancel();
+}

--- a/lib/provider/utils/waiter.dart
+++ b/lib/provider/utils/waiter.dart
@@ -23,7 +23,7 @@ Worker wait<T>(
     onDone: onDone,
     cancelOnError: cancelOnError,
   );
-  return Worker(sub.cancel, '[debounce]');
+  return Worker(sub.cancel, '[wait]');
 }
 
 class _Waiter {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,7 +149,7 @@ packages:
     description:
       path: "."
       ref: p-lyric-app
-      resolved-ref: "0262228e49c184b7fb07f8f7deb3b65a2505f667"
+      resolved-ref: af3536fc2d01c94f464cc4a645a6c8389fec3fe9
       url: "https://github.com/jja08111/nowplaying.git"
     source: git
     version: "2.0.2"

--- a/test/worker/worker_test.dart
+++ b/test/worker/worker_test.dart
@@ -1,0 +1,24 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:p_lyric/provider/utils/waiter.dart';
+import 'package:get/get.dart';
+
+void main() {
+  test('wait', () async {
+    final count = 0.obs;
+    int? result = -1;
+    wait(count, (dynamic _) {
+      result = _ as int?;
+    }, time: const Duration(milliseconds: 100));
+
+    count.value++;
+    count.value++;
+    count.value++;
+    count.value++;
+    await Future.delayed(Duration.zero);
+    expect(1, result);
+    await Future.delayed(const Duration(milliseconds: 100));
+    expect(4, result);
+  });
+}


### PR DESCRIPTION
## 😅 변경사항
- `AndroidMenifest`에서 `Intent-service`를 사용하는경우 명시적으로 exported 값을 넣어야 해 false 값을 추가
 > android:exported: 이 요소는 다른 애플리케이션의 구성요소로 액티비티를 시작할 수 있는지 설정합니다. 할 수 있으면 " true ", 할 수 없으면 "false".
- NowPlaying 플러그인의 잘못된 null-safety 적용을 수정
- 노래가 변경되면 즉시 가사 찾는 함수가 실행되도록 수정. 1초 이내의 중복된 명령이 있는경우 대기하는 것은 유지됩니다. 즉 이전에는 요청을 받으면 대기한 다음에 명령이 실행되었다면, 이번에는 요청을 받고 바로 실행한 후 명령이 또 요청되면 대기하였다가 실행하는 방식입니다. 테스트 코드 또한 추가했습니다.

## 😁 결과
- **모든 뮤직 플레이어에서 음악 정보를 가져올 수 있음!!!**
- 빠른 가사 업데이트 반응

## 🙄 참고
- [안드로이드 액티비티](https://developer.android.com/guide/topics/manifest/activity-element?hl=ko)
- https://github.com/jja08111/nowplaying/commit/af3536fc2d01c94f464cc4a645a6c8389fec3fe9 커밋에서 nowplaying 플러그인의 수정사항 확인 가능