### PR TITLE
멜론 검색 최적화를 위한  전처리 기능 추가

### DIFF
--- a/lib/provider/song_data_preprocess.dart
+++ b/lib/provider/song_data_preprocess.dart
@@ -1,0 +1,67 @@
+class SongDataPreprocess {
+  static RegExp _korean = new RegExp(r"^[가-힣 ]*$");
+  static RegExp _english = new RegExp(r"^[a-zA-Z ]*$");
+
+  static bool _isStartWithKorean(String title) {
+    bool ret;
+    ret = _korean.hasMatch(title.split("")[0]) ? true : false;
+
+    return ret;
+  }
+
+  /// 영어와 한국어가 섞여 있을 경우, 첫 단어를 기준으로 그에 맞는 언어로만 구성된 `String` 을 리턴
+  static String _divideLanguage(String target, bool isKorean) {
+    String korExtract = "";
+    String engExtract = "";
+
+    List<String> words = target.split("");
+
+    for (int i = 0; i < words.length; i++) {
+      if (words[i] == "  ") {
+        korExtract += words[i];
+        engExtract += words[i];
+        continue;
+      }
+
+      if (_korean.hasMatch(words[i]))
+        korExtract += words[i];
+      else
+        engExtract += words[i];
+    }
+
+    return isKorean ? korExtract : engExtract;
+  }
+
+  static String filterSongTitle(String title) {
+    String filteredTitle = "";
+
+    filteredTitle = title.split("(피처링")[0];
+
+    // 제목에 영어와 한국어 모두 포함되어있을 때
+    if (!_korean.hasMatch(filteredTitle) && !_english.hasMatch(filteredTitle)) {
+      bool isKorean = _isStartWithKorean(title);
+      filteredTitle = _divideLanguage(title, isKorean);
+    }
+
+    return filteredTitle;
+  }
+
+  /// `filterArtist` 는 멜론 검색에 최적화 된 가수명 필터링 함수이다.
+  /// 따라서 멜론에서 검색될 수 있는 정보만 필터링해온다.
+  static String filterArtist(String artist) {
+    String filteredArtist = "";
+
+    filteredArtist = artist.split(", ")[0];
+    filteredArtist = filteredArtist.split(" 및")[0]; // `및` 이 들어가 있는 가수명은 필터링한다.
+    filteredArtist = filteredArtist.split("(")[0]; // 괄호안에 가수의 영문을 써놓는 경우 제외시킨다.
+
+    // 위 필터링 과정을 거쳐도 남아있는 영문과 한글이 혼용되있는 경우를 필터링한다.
+    if (!_korean.hasMatch(filteredArtist) &&
+        !_english.hasMatch(filteredArtist)) {
+      bool isKorean = _isStartWithKorean(filteredArtist);
+      filteredArtist = _divideLanguage(filteredArtist, isKorean);
+    }
+
+    return filteredArtist;
+  }
+}

--- a/lib/services/melon_lyric_scraper.dart
+++ b/lib/services/melon_lyric_scraper.dart
@@ -1,6 +1,7 @@
 import 'package:http/http.dart' as http;
 import 'package:html/parser.dart' as parser;
 import 'package:html/dom.dart' as dom;
+import 'package:p_lyric/provider/song_data_preprocess.dart';
 
 class MelonLyricScraper {
   // TODO(시현) : 아래의 `proxyUrl` 이 `web build`에서만 작동되는 문제 해결해야됨.
@@ -31,7 +32,7 @@ class MelonLyricScraper {
 
     return parsedString;
   }
-  
+
   // TODO(시현, 민성): 곡 정보를 어떻게 가공하냐에 따라 매개변수 searchedSongUrl을 `title, artist` 형태로 바꿀지 말지 결정
   static Future<String> _getSongID(String searchedSongUrl) async {
     String songID;
@@ -47,18 +48,23 @@ class MelonLyricScraper {
       }).toList();
       if (lyricList.length < 2) {
         // 맨 위에 전체선택 체크박스 포함
-        return '곡 정보가 없습니다.';
+        return '곡 정보가 없습니다 😢';
       }
 
       // 0번째 인덱스는 `모든 체크박스`의 값이다. 따라서 1번째 값을 이용한다.
       songID = lyricList[1] ?? '';
       return songID;
     } catch (e) {
-      return '노래ID 검색 에러 발생: $e';
+      return '🤔 노래 검색 에러\n$e';
     }
   }
 
-  static Future<String> getLyrics(String title, String artist) async {
+  static Future<String> getLyrics(String songTitle, String songArtist) async {
+    if (songTitle == '' || songArtist == '') return "곡 정보가 없습니다 😢";
+
+    String title = SongDataPreprocess.filterArtist(songTitle);
+    String artist = SongDataPreprocess.filterArtist(songArtist);
+
     String searchPageUrl = _getSearchPageUrl(title, artist);
     String songID = await _getSongID(searchPageUrl);
 
@@ -71,11 +77,12 @@ class MelonLyricScraper {
         return _parseHtmlString(e);
       });
 
-      if (lyricList.isEmpty) throw 'Lyric Empty';
+      if (lyricList.isEmpty)
+        throw '가사를 찾을 수 없습니다\nTitle : $title\nArtist : $artist';
 
       return lyricList.join('\n');
     } catch (e) {
-      return '$title 가사 검색 에러 발생: $e $songID';
+      return '🤔 노래 검색 에러\n$e';
     }
   }
 }

--- a/lib/services/melon_lyric_scraper.dart
+++ b/lib/services/melon_lyric_scraper.dart
@@ -1,7 +1,7 @@
 import 'package:http/http.dart' as http;
 import 'package:html/parser.dart' as parser;
 import 'package:html/dom.dart' as dom;
-import 'package:p_lyric/provider/song_data_preprocess.dart';
+import 'package:p_lyric/services/song_data_preprocessor.dart';
 
 class MelonLyricScraper {
   // TODO(시현) : 아래의 `proxyUrl` 이 `web build`에서만 작동되는 문제 해결해야됨.
@@ -62,8 +62,8 @@ class MelonLyricScraper {
   static Future<String> getLyrics(String songTitle, String songArtist) async {
     if (songTitle == '' || songArtist == '') return "곡 정보가 없습니다 😢";
 
-    String title = SongDataPreprocess.filterArtist(songTitle);
-    String artist = SongDataPreprocess.filterArtist(songArtist);
+    String title = SongDataPreprocessor.filterArtist(songTitle);
+    String artist = SongDataPreprocessor.filterArtist(songArtist);
 
     String searchPageUrl = _getSearchPageUrl(title, artist);
     String songID = await _getSongID(searchPageUrl);

--- a/lib/services/song_data_preprocessor.dart
+++ b/lib/services/song_data_preprocessor.dart
@@ -1,0 +1,67 @@
+class SongDataPreprocessor {
+  static RegExp _korean = new RegExp(r"^[가-힣 ]*$");
+  static RegExp _english = new RegExp(r"^[a-zA-Z ]*$");
+
+  static bool _isStartWithKorean(String title) {
+    bool ret;
+    ret = _korean.hasMatch(title.split("")[0]) ? true : false;
+
+    return ret;
+  }
+
+  /// 영어와 한국어가 섞여 있을 경우, 첫 단어를 기준으로 그에 맞는 언어로만 구성된 `String` 을 리턴
+  static String _divideLanguage(String target) {
+    final bool isKorean = _isStartWithKorean(target);
+    String korExtract = "";
+    String engExtract = "";
+
+    List<String> words = target.split("");
+
+    for (final word in words) {
+      if (word == "  ") {
+        korExtract += word;
+        engExtract += word;
+        continue;
+      }
+
+      if (_korean.hasMatch(word))
+        korExtract += word;
+      else
+        engExtract += word;
+    }
+
+    return isKorean ? korExtract : engExtract;
+  }
+
+  /// 노래 제목을 멜론 검색에 최적화된 `filteredTitle` 을 반환한다.
+  static String filterSongTitle(String title) {
+    String filteredTitle = "";
+
+    filteredTitle = title.split("(피처링")[0];
+
+    // 제목에 영어와 한국어 모두 포함되어있을 때
+    if (!_korean.hasMatch(filteredTitle) && !_english.hasMatch(filteredTitle))
+      filteredTitle = _divideLanguage(title);
+
+    return filteredTitle;
+  }
+
+  /// 멜론 검색에 최적화 된 가수명 필터링 함수이다.
+  ///
+  /// `artist` 값을 전처리를 진행하여 멜론에서 검색될 수 있는 정보만 필터링해온다.
+  /// 이때 가수명에 콤마와 `및` 이 포함된 경우는 `split`을 통해 앞에 있는 정보만 가져온다.
+  /// 또한 괄호안에 가수의 영문을 써놓는 경우 제외시킨다.
+  /// 위의 과정을 거쳐도 한글과 영문이 혼용되있을 경우도 마지막으로 필터링한다.
+  static String filterArtist(String artist) {
+    String filteredArtist = "";
+
+    filteredArtist = artist.split(", ")[0];
+    filteredArtist = filteredArtist.split(" 및")[0];
+    filteredArtist = filteredArtist.split("(")[0];
+
+    if (!_korean.hasMatch(filteredArtist) && !_english.hasMatch(filteredArtist))
+      filteredArtist = _divideLanguage(filteredArtist);
+
+    return filteredArtist;
+  }
+}


### PR DESCRIPTION
# What's New? 😎
* song_data_preprocess.dart 
* 해당 클래스는 멜론 검색의 최적화를 위한 전처리 기능을 포함하고 있음
* 필터링된 정보들은 `MelonLyricScraper` 의 `getLyrics` 에서 받음

# What should I fix? 🤦‍♂️
- [ ]  이 필터링에 포함되지 않는 예외사항들이 많음 (ex. 악동뮤지션은 이제 멜론에서 `AKMU` 라 검색해야됨)
- [ ] 유튜브 뮤직 내에서 구글 측에서 번역해둔 대로 필터링하고 멜론에서 검색하면 안뜨는 경우도 있음
