### PR TITLE
테마 변경시 일부 적용이 안되던 버그 해결

### DIFF
--- a/lib/views/home_page.dart
+++ b/lib/views/home_page.dart
@@ -296,7 +296,9 @@ class _CardView extends StatelessWidget {
                     builder: (musicProvider) => Text(
                       musicProvider.track?.artist ?? '노래를 재생하면 가사가 업데이트됩니다.',
                       style: textTheme.subtitle2!.copyWith(
-                        color: Get.isDarkMode ? Colors.white54 : Colors.black54,
+                        color: context.isDarkMode
+                            ? Colors.white54
+                            : Colors.black54,
                       ),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
@@ -389,7 +391,7 @@ class _ControlBarState extends State<_ControlBar>
   Widget build(BuildContext context) {
     return IconTheme(
       data: IconThemeData(
-        color: Get.isDarkMode ? Colors.white : Colors.black,
+        color: context.isDarkMode ? Colors.white : Colors.black,
       ),
       child: GetBuilder<MusicProvider>(
         builder: (musicProvider) {


### PR DESCRIPTION
### 변경사항
- 시스템 테마를 전환했을 때 카드 뷰의 텍스트와 버튼의 색상이 변경되지 않던 문제를 해결

### 참조
- https://stackoverflow.com/questions/64076415/fonts-theme-doesnt-rebuilt-properly-as-user-changed-the-apps-theme-getx-stat