### PR TITLE
Flutter, Dart SDK 버전 업그레이드 및 패키지 버전 업데이트

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   nowplaying:
     dependency: "direct main"
     description:
@@ -248,7 +248,7 @@ packages:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -330,7 +330,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
@@ -367,5 +367,5 @@ packages:
     source: hosted
     version: "0.2.0"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=2.14.2 <3.0.0"
+  flutter: ">=2.5.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.2 <3.0.0"
 
 dependencies:
   flutter:
@@ -30,8 +30,8 @@ dependencies:
     git:
       url: https://github.com/jja08111/nowplaying.git
       ref: p-lyric-app
-  shared_preferences: ^2.0.7
-  permission_handler: ^8.1.4+2
+  shared_preferences: ^2.0.8
+  permission_handler: ^8.1.6
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
- Flutter SDK 2.5.1로 업그레이드
- Dart SDK 2.14.2로 업그레이드
- 플러그인 버전 업데이트
  - shared_preferences: 2.0.8
  - permission_handler: 8.1.6