### PR TITLE
Upgrade flutter, dart version and fix NameNotFoundException warning

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 
     <application
         android:icon="@mipmap/ic_launcher"

--- a/lib/views/home_page.dart
+++ b/lib/views/home_page.dart
@@ -294,7 +294,7 @@ class _AlbumCoverImage extends StatelessWidget {
               duration: kThemeChangeDuration,
               child: hasImage
                   ? Image(
-                      image: image!,
+                      image: image,
                       height: imageDiameter,
                       width: imageDiameter,
                     )

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -330,7 +330,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -344,7 +344,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   web_scraper:
     dependency: "direct main"
     description:
@@ -367,5 +367,5 @@ packages:
     source: hosted
     version: "0.2.0"
 sdks:
-  dart: ">=2.14.2 <3.0.0"
+  dart: ">=2.15.0 <3.0.0"
   flutter: ">=2.5.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.14.2 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/test/worker/worker_test.dart
+++ b/test/worker/worker_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:p_lyric/provider/utils/waiter.dart';
 import 'package:get/get.dart';


### PR DESCRIPTION
## 변경사항
- Flutter와 Dart 의 버전을 각각 2.8.1, 2.15.0으로 업데이트 
      -> dart 버전을 업데이트하니 추가 warning이 발생하여 `home_page.dart`와 `worker_test.dart` 파일 수정함
- AndroidManifest 파일에 권한을 추가하여서 NameNotFoundException 경고를 보이지 않도록 해결